### PR TITLE
Added the appropriate categories in the .desktop file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -126,9 +126,10 @@ install_x_driver()      {
 install_dot_desktop()   {
     install -D -m$2 "$1" "${pkgdir}/usr/share/applications/$1"
 
-    # Set the appropriate paths in the .desktop file
-    sed -i -e s:__UTILS_PATH__:/usr/bin: \
-           -e s:__PIXMAP_PATH__:/usr/share/doc/nvidia: \
+    # Set the appropriate paths and categories in the .desktop file
+    sed -i -e 's:__UTILS_PATH__:/usr/bin:' \
+           -e 's:__PIXMAP_PATH__:/usr/share/doc/nvidia:' \
+           -e 's:Application;Settings;:Settings;HardwareSettings;:' \
            "${pkgdir}/usr/share/applications/$1"
 }
 


### PR DESCRIPTION
According to "Desktop Menu Specification" [1] and "Desktop Entry Specification" [2]
"Application" is valid for the "Type" key only.

Related to FS#48307 [3]

[1] https://specifications.freedesktop.org/menu-spec/menu-spec-latest.html#introduction
[2] https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
[3] https://bugs.archlinux.org/task/48307

Signed-off-by: Darek Zielski dz1125.bug.tracker@gmail.com
